### PR TITLE
feat: resend account activation email

### DIFF
--- a/users/signals.py
+++ b/users/signals.py
@@ -26,7 +26,4 @@ def send_activation_email_signal(sender, instance, created, **kwargs):
             import traceback
 
             traceback.print_exc()
-    else:
-        print(
-            f"Condition NOT met - created: {created}, is_active: {instance.is_active}"
-        )
+    return

--- a/users/tasks.py
+++ b/users/tasks.py
@@ -5,7 +5,21 @@ from django.core.mail import send_mail
 
 @shared_task
 def send_activation_email(email, confirmation_url):
-    print(f"Sending to {email} with link {confirmation_url}")
     subject = "Confirm your email"
-    message = f"Click the link to activate your account: {confirmation_url}"
+    message = f"""
+    Welcome! Thank you for registering.\n
+
+    Please click the link below to activate your account:\n
+    {confirmation_url}\n
+
+    This link will expire in 24 hours for security reasons.\n
+
+    If you didn't create this account, please ignore this email.\n
+
+    Best regards,
+    The Team
+    """
+    send_mail(
+        subject, message, settings.DEFAULT_FROM_EMAIL, [email], fail_silently=False
+    )
     send_mail(subject, message, settings.DEFAULT_FROM_EMAIL, [email])

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,13 @@
 from django.urls import path
 
-from .views import RegisterAPIView, confirmEmailView
+from .views import RegisterAPIView, ResendActivationEmailView, confirmEmailView
 
 urlpatterns = [
     path("register/", RegisterAPIView.as_view(), name="register"),
     path("confirm-email/", confirmEmailView.as_view(), name="confirm-email"),
+    path(
+        "resend-activation-email/",
+        ResendActivationEmailView.as_view(),
+        name="resend-activation",
+    ),
 ]


### PR DESCRIPTION
### 🔧 **Resend Activation Email Endpoint + Cleanup**

#### ✅ What's Implemented:

1. **New API Endpoint: `POST /api/users/resend-activation-email/`**

   * Allows users to request a resend of their activation email.
   * Returns a generic success message for both existing and non-existent users.
   * Blocks already activated accounts with a specific error.

2. **Updated Activation Email Template**

   * Changed from:

     ```
     Click the link to activate your account: <link>
     ```
   * To a more professional full-body message with expiration note and support tone.

3. **`signals.py` Cleanup**

   * Removed debug `print()` used for dev testing.
   * Replaced with a `return` for clean signal handling post-failure.

---

#### 🧪 Tests:

* Covers missing email, already activated users, valid resends, and non-existent emails.
* Used mock to prevent actual email sends during test runs.